### PR TITLE
fixed passing tests with 404 urls

### DIFF
--- a/Test.pm
+++ b/Test.pm
@@ -60,6 +60,7 @@ sub test {
         . "Status Line: "
         . $res->message . "\n";
       sleep 1;
+      $res = $self->ua->get("http://$host:$port$loc");
     }
     Rex::Logger::info("Done Testing.);
   }

--- a/Test.pm
+++ b/Test.pm
@@ -47,7 +47,11 @@ sub test {
     Rex::Logger::info("Testing: http://$host:$port$loc");
     my $res = $self->ua->get("http://$host:$port$loc");
 
-    if ( $res->code != $self->expected_code && scalar @failures < 3 ) {
+    while ( $res->code != $self->expected_code ) {
+      if (scalar @failures > 3) {
+        Rex::Logger::info( $_, "error" ) for @failures;
+        die "Test failed.";
+      }
       Rex::Logger::info("Error testing. Retrying...");
       push @failures,
           "Error testing url: http://$host:$port$loc\n"
@@ -57,12 +61,8 @@ sub test {
         . $res->message . "\n";
       sleep 1;
     }
-    elsif ( $res->code != $self->expected_code && scalar @failures >= 3 ) {
-      Rex::Logger::info( $_, "error" ) for @failures;
-      die "Test failed.";
-    }
+    Rex::Logger::info("Done Testing.);
   }
-
 }
 
 1;


### PR DESCRIPTION
Tests for URLs with 404 (and maybe other http codes) pass and job doesn't fail. 
This fix improves retrying and handles errors which are not HTTP 200. 
